### PR TITLE
upgrade Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,15 @@
-all: buildd publish
+BUILDVERSION=$(shell git describe --tags --always)
+
+all: buildd docker
 
 buildd:
 	yarn build
 
-publish:
-	docker build -t influxdb-ui:latest .
+docker: buildd
+	docker build -t influxdb-ui:$(BUILDVERSION) .
 
+publish: buildd docker
+	docker tag influxdb-ui:$(BUILDVERSION) sillydong/influxdb-ui:$(BUILDVERSION)
+	docker tag influxdb-ui:$(BUILDVERSION) sillydong/influxdb-ui:latest
+	docker push sillydong/influxdb-ui:$(BUILDVERSION)
+	docker push sillydong/influxdb-ui:latest


### PR DESCRIPTION
I made some change to Makefile, add git version for docker image tag.

Currently I push image to [https://hub.docker.com/r/sillydong/influxdb-ui](https://hub.docker.com/r/sillydong/influxdb-ui), I wonder would you create an official docker repo for this project? So that release images can be pushed there. Or if you feel ok with my repo for users to download.