### PR TITLE
Always pass credentials to InfluxAPI.getDatabaseList

### DIFF
--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -141,7 +141,7 @@ class NavServerList extends Component {
     console.log(currentServer);
 
     //  Reset the database list:
-    InfluxAPI.getDatabaseList(currentServer.url);
+    InfluxAPI.getDatabaseList(currentServer.url, currentServer.username, currentServer.password);
   }
 }
 

--- a/src/components/Settings.js
+++ b/src/components/Settings.js
@@ -184,7 +184,7 @@ class Settings extends Component {
       let currentServer = SettingsStore.getCurrentServer();
 
       //  Reset the database list:
-      InfluxAPI.getDatabaseList(currentServer.url);
+      InfluxAPI.getDatabaseList(currentServer.url, currentServer.username, currentServer.password);
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ SettingsAPI.getSettings();
 if(!SettingsStore.needCurrentServer()){
     let currentServer = SettingsStore.getCurrentServer();
     console.log(currentServer);
-    InfluxAPI.getDatabaseList(currentServer.url);
+    InfluxAPI.getDatabaseList(currentServer.url, currentServer.username, currentServer.password);
   }
 
 ReactDOM.render(<App />, document.getElementById('root'));


### PR DESCRIPTION
Often only the server url was passed to InfluxAPI.getDatabaseList and the credentials were missing. Thus leading to 403 errors from the server when authentication is enabled.