### PR TITLE
optimize docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM node:latest as build
 WORKDIR /app
-COPY . /app
-RUN yarn install && yarn build
+COPY package.json yarn.lock ./
+RUN yarn install
+COPY . ./
+RUN yarn build
 
 FROM nginx:stable-alpine
 COPY --from=build /app/build /usr/share/nginx/html


### PR DESCRIPTION
This change makes docker build cache the installed packages as long as `package.json` or `yarn.lock` don't change. This improves docker build performance drastically when only code changes are made.